### PR TITLE
A :multi spec key for repeated options

### DIFF
--- a/src/main/clojure/clojure/tools/cli.clj
+++ b/src/main/clojure/clojure/tools/cli.clj
@@ -72,6 +72,12 @@
                 extra-args
                 (rest args))
 
+         (and (opt? opt) (spec :multi))
+         (recur (update-in options [(spec :name)] #(conj (or %1 []) %2)
+                           ((spec :parse-fn) (second args)))
+                extra-args
+                (drop 2 args))
+
          (opt? opt)
          (recur (assoc options (spec :name) ((spec :parse-fn) (second args)))
                 extra-args


### PR DESCRIPTION
Uses update-in and conj to update a vector value.

(first (cli ["-x" "1" "-x" "2"] ["-x" :multi true])) ; => {:x ["1" "2"]}
