### PR TITLE
Add combiner-fn option

### DIFF
--- a/src/main/clojure/clojure/tools/cli.clj
+++ b/src/main/clojure/clojure/tools/cli.clj
@@ -51,6 +51,10 @@
   [specs]
   (into {} (for [s specs] [(s :name) (s :default)])))
 
+(defn- update-options [options spec val]
+  (let [parsed ((spec :parse-fn) val)]
+    (update-in options [(spec :name)] #((spec :combine-fn) % parsed))))
+
 (defn- apply-specs
   [specs args]
   (loop [options    (default-values-for specs)
@@ -73,7 +77,7 @@
                 (rest args))
 
          (opt? opt)
-         (recur (assoc options (spec :name) ((spec :parse-fn) (second args)))
+         (recur (update-options options spec (second args))
                 extra-args
                 (drop 2 args))
 
@@ -102,7 +106,8 @@
             :name     (keyword (last aliases))
             :parse-fn identity
             :default  (if flag false nil)
-            :flag     flag}
+            :flag     flag
+            :combine-fn (fn [old new] new)}
            options)))
 
 (defn cli

--- a/src/test/clojure/clojure/tools/cli_test.clj
+++ b/src/test/clojure/clojure/tools/cli_test.clj
@@ -72,6 +72,13 @@
         (is (= {:foo "bar" :verbose true} options))
         (is (= ["file" "-x" "other"] args))))))
 
+(deftest combiner-options
+  (let [[options _ _] (cli ["-a" "bar" "-e" "apple" "-a" "foo" "-e" "banana" "-e" "carrot"]
+                                  ["-a"]
+                                  ["-e" :combine-fn concat :parse-fn vector])]
+        (is (= {:a "foo" :e ["apple" "banana" "carrot"]} options))
+        ))
+
 (deftest all-together-now
   (let [[options args _] (cli ["-p" "8080"
                                "--no-verbose"


### PR DESCRIPTION
Add combiner-fn to support things like having multiple values for the same switch, e.g.:

```
-a 1 --config val1 --config val2
```

An example is in the tests.
