### PR TITLE
Add compilation of spec vector to summarize

### DIFF
--- a/src/main/clojure/cljs/tools/cli.cljs
+++ b/src/main/clojure/cljs/tools/cli.cljs
@@ -287,7 +287,7 @@
   [specs]
   (if (seq specs)
     (let [show-defaults? (some #(and (:required %) (contains? % :default)) specs)
-          parts (map (partial make-summary-parts show-defaults?) specs)
+          parts (map (partial make-summary-parts show-defaults?) (compile-option-specs specs))
           lens (apply map (fn [& cols] (apply max (map count cols))) parts)
           lines (format-lines lens parts)]
       (s/join \newline lines))


### PR DESCRIPTION
The compilation of the spec vectors to the spec map is missing in `summarize`. This leads to a fail of the destructuring of `specs` within `make-summary-parts`.